### PR TITLE
Add better mediafusion public instance as primary with other kept as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* [v2.95.0](https://github.com/a4k-openproject/a4kScrapers/releases/tag/a4kScrapers-2.96.0):
+* [v2.96.0](https://github.com/a4k-openproject/a4kScrapers/releases/tag/a4kScrapers-2.96.0):
   * Add better mediafusion public instance as primary with other kept as fallback
 
 * [v2.95.0](https://github.com/a4k-openproject/a4kScrapers/releases/tag/a4kScrapers-2.95.0):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-* [v2.95.0](https://github.com/a4k-openproject/a4kScrapers/releases/tag/a4kScrapers-2.94.0):
+* [v2.95.0](https://github.com/a4k-openproject/a4kScrapers/releases/tag/a4kScrapers-2.96.0):
+  * Add better mediafusion public instance as primary with other kept as fallback
+
+* [v2.95.0](https://github.com/a4k-openproject/a4kScrapers/releases/tag/a4kScrapers-2.95.0):
   * Change mediafusion public instance (elfhosted depricated)
 
 * [v2.94.0](https://github.com/a4k-openproject/a4kScrapers/releases/tag/a4kScrapers-2.94.0):

--- a/meta.json
+++ b/meta.json
@@ -1,6 +1,6 @@
 {
   "author": "Unknown",
-  "version":"2.95.0",
+  "version":"2.96.0",
   "name":"a4kScrapers",
   "update_directory": "https://github.com/a4k-openproject/a4kScrapers/archive/",
   "remote_meta": "https://raw.githubusercontent.com/newt-sc/a4kScrapers/master/meta.json",

--- a/providerModules/a4kScrapers/urls.json
+++ b/providerModules/a4kScrapers/urls.json
@@ -116,6 +116,7 @@
           "cat_movie": "movie",
           "cat_episode": "series",
           "domains": [
+              { "base": "https://mediafusion.stremio.ru" },
               { "base": "https://mediafusionfortheweebs.midnightignite.me" }
           ]
       },

--- a/providers/a4kScrapers/en/torrent/mediafusion.py
+++ b/providers/a4kScrapers/en/torrent/mediafusion.py
@@ -42,7 +42,9 @@ class sources(core.DefaultSources):
         if self._ad_apikey:
             params += '|alldebrid=' + self._ad_apikey
 
-        config = 'D-VB6XV7ihJSEIwDttLGJEBwGOm5jk0SauzzN776n-vpQACSP9gqDv6r_EOlRRgXABiH52LcNFY3QdsRHHlqHId-ZwrsLx3RkuaW4fp3LzLP8'
+        if 'ru' in url.base: 
+            config = 'D-cL6-bnks38LpUSoByVLy0vFJEH1S2qqt7K1Tw7tG6_iUy7Znn5w04YKnJBUGbthk978Ag1aKEMbGj8-qNOBmLlBf5ccM3N8q49dtETI2YDs'
+        else: config = 'D-VB6XV7ihJSEIwDttLGJEBwGOm5jk0SauzzN776n-vpQACSP9gqDv6r_EOlRRgXABiH52LcNFY3QdsRHHlqHId-ZwrsLx3RkuaW4fp3LzLP8'
         request_url = url.base + '/' + core.quote_plus(config) + (url.search % core.quote_plus(query))
         response = self._request.get(request_url)
 


### PR DESCRIPTION
I have been doing some testing and this other public instance seems to have a fair number of extra results and quicker overall response time (when doing live searches and when results are cached). 

I added it as the primary with the other as the fallback and change the config accordingly if the existing logic deprioritizes the primary url for the current session.